### PR TITLE
Expose WebUI backend baseUrl config value

### DIFF
--- a/nephio-webui/config-map.yaml
+++ b/nephio-webui/config-map.yaml
@@ -7,6 +7,12 @@ data:
   app-config.nephio.yaml: |
     # Backstage backend configuration
     backend:
+      # Note that the baseUrl should be the URL that the browser and other clients
+      # should use when communicating with the backend, i.e. it needs to be
+      # reachable not just from within the backend host, but from all of your
+      # callers. When its value is "http://localhost:7007", it's strictly private
+      # and can't be reached by others.
+      baseUrl: http://localhost:7007 # kpt-set: ${backend-base-url}
       # Content Security Policy
       csp:
         # Allows images to be pulled from GitHub and Nepio


### PR DESCRIPTION
Some deployments require [customizing](https://github.com/backstage/backstage/issues/13194#issuecomment-1260822097) this value to avoid CORS issue. This change allows to expose the `baseUrl` backstage configuration value.