### PR TITLE
Create initial version of UERANSIM kpt package

### DIFF
--- a/ueransim/Kptfile
+++ b/ueransim/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: ueransim
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: this package represents ueransim NFs, which are required to perfirm E2E conn testing
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configPath: package-context.yaml

--- a/ueransim/README.md
+++ b/ueransim/README.md
@@ -1,0 +1,24 @@
+# ueransim
+
+## Description
+sample description
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] ueransim`
+
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree ueransim`
+
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init ueransim
+kpt live apply ueransim --reconcile-timeout=2m --output=table
+```
+
+Details: https://kpt.dev/reference/cli/live/

--- a/ueransim/gnb/gnb-configmap.yaml
+++ b/ueransim/gnb/gnb-configmap.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gnb-configmap
+  labels:
+    app.kubernetes.io/version: "v3.2.6"
+    app: ueransim
+    component: gnb
+data:
+  gnb-config.yaml: |
+    mcc: '208'          # Mobile Country Code value
+    mnc: '93'           # Mobile Network Code value (2 or 3 digits)
+    nci: '0x000000010'  # NR Cell Identity (36-bit)
+    idLength: 32        # NR gNB ID length in bits [22...32]
+    tac: 1              # Tracking Area Code
+    # List of supported S-NSSAIs by this gNB
+    slices:
+      - sst: 0x1
+        sd: 0x010203
+    # Indicates whether or not SCTP stream number errors should be ignored.
+    ignoreStreamIds: true
+    
+    linkIp: 0.0.0.0   # gNB's local IP address for Radio Link Simulation (Usually same with local IP)
+    # gNB's local IP address for N2 Interface (Usually same with local IP)
+    ngapIp: 10.100.50.250
+    gtpIp: 10.0.0.20    # gNB's local IP address for N3 Interface (Usually same with local IP)
+    
+    # List of AMF address information
+    amfConfigs:
+      - address: 10.100.50.249
+        port: 38412
+

--- a/ueransim/gnb/gnb-deployment.yaml
+++ b/ueransim/gnb/gnb-deployment.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ueransim-gnb
+  labels:
+    app.kubernetes.io/version: "v3.2.6"
+    app: ueransim
+    component: gnb
+spec:
+  selector:
+    matchLabels:
+      app: ueransim
+      component: gnb
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ueransim
+        component: gnb
+      annotations:
+        k8s.v1.cni.cncf.io/networks: '[
+            { "name": "n2network-ueransim-ueransim",
+              "interface": "n2",
+              "ips": [ "10.100.50.250/29" ],
+              "gateway": [ "10.100.50.254" ]
+            },
+            { "name": "n3network-ueransim-ueransim",
+              "interface": "n3",
+              "ips": [ "10.0.0.20/24" ],
+              "gateway": [ "10.0.0.1" ]
+            }          
+            ]'
+
+    spec:
+      containers:
+      - image: towards5gs/ueransim-gnb:v3.2.6
+        imagePullPolicy: IfNotPresent
+        name: gnb
+        ports:
+        - name: gnb-ue
+          containerPort: 4997
+          protocol: UDP
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
+        command: ["./nr-gnb"]
+        args: ["-c", "/ueransim/config/gnb-config.yaml"]  
+        volumeMounts:
+        - mountPath: /ueransim/config
+          name: gnb-volume
+        resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: gnb-volume
+        configMap:
+          name: gnb-configmap

--- a/ueransim/gnb/gnb-n2-nad.yaml
+++ b/ueransim/gnb/gnb-n2-nad.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: n2network-ueransim-ueransim
+  namespace: default
+spec:
+  config: '{
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "capabilities": { "ips": true },
+          "master": "ens3",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static",
+            "routes": [
+              {
+                "dst": "0.0.0.0/0",
+                "gw": "10.100.50.254"
+              }
+            ] 
+          }
+        }, {
+          "capabilities": { "mac": true },
+          "type": "tuning"
+        }
+      ]
+    }'

--- a/ueransim/gnb/gnb-n3-nad.yaml
+++ b/ueransim/gnb/gnb-n3-nad.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: n3network-ueransim-ueransim
+  namespace: default
+spec:
+  config: '{
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "capabilities": { "ips": true },
+          "master": "ens3",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static",
+            "routes": [
+              {
+                "dst": "0.0.0.0/0",
+                "gw": "10.0.0.1"
+              }
+            ] 
+          }
+        }, {
+          "capabilities": { "mac": true },
+          "type": "tuning"
+        }
+      ]
+    }'

--- a/ueransim/gnb/gnb-service.yaml
+++ b/ueransim/gnb/gnb-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gnb-service
+  labels:
+    app.kubernetes.io/version: "v3.2.6"
+    app: ueransim
+    component: gnb
+spec:
+  type: ClusterIP
+  ports:
+    - name: gnb-ue
+      port: 4997
+      protocol: UDP
+  selector:
+    app: ueransim
+    component: gnb

--- a/ueransim/namespace.yaml
+++ b/ueransim/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default

--- a/ueransim/package-context.yaml
+++ b/ueransim/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: ueransim
+  namespace: ueransim

--- a/ueransim/ue/ue-configmap.yaml
+++ b/ueransim/ue/ue-configmap.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ue-configmap
+  labels:
+    app.kubernetes.io/version: "v3.2.6"
+    app: ueransim
+    component: ue
+data:
+  ue-config.yaml: |
+    supi: "imsi-208930000000003"  # IMSI number
+    mcc: '208' # Mobile Country Code value
+    mnc: '93' # Mobile Network Code value (2 or 3 digits)
+    key: "8baf473f2f8fd09487cccbd7097c6862" # Operator code (OP or OPC) of the UE
+    op: "8e27b6af0e692e750f32667a3b14605d" # This value specifies the OP type and it can be either 'OP' or 'OPC'
+    opType: "OPC" # This value specifies the OP type and it can be either 'OP' or 'OPC'
+    amf: '8000' # Authentication Management Field (AMF) value
+    imei: '356938035643803' # IMEI number of the device
+    imeiSv: '4370816125816151'
+    # UAC Access Identities Configuration
+    uacAic:
+      mps: false
+      mcs: false
+    # UAC Access Control Class
+    uacAcc:
+      normalClass: 0
+      class11: false
+      class12: false
+      class13: false
+      class14: false
+      class15: false
+    sessions:
+      - type: "IPv4"
+        apn: "internet"
+        slice:
+          sst: 0x01
+          sd: 0x010203
+    # Configured NSSAI for this UE by HPLMN
+    configured-nssai:
+      - sst: 0x01
+        sd: 0x010203
+    # Default Configured NSSAI for this UE
+    default-nssai:
+      - sst: 1
+        sd: 1
+    # Supported encryption and integrity algorithms by this UE
+    integrity:
+      IA1: true
+      IA2: true
+      IA3: true
+    ciphering:
+      EA1: true
+      EA2: true
+      EA3: true
+    # Integrity protection maximum data rate for user plane
+    integrityMaxRate:
+      uplink: 'full'
+      downlink: 'full'
+    
+    # List of gNB IP addresses for Radio Link Simulation
+    gnbSearchList:
+      - gnb-service
+
+  wrapper.sh: |
+    #!/bin/bash
+
+    mkdir /dev/net
+    mknod /dev/net/tun c 10 200
+
+    ./nr-ue -c ../config/ue-config.yaml

--- a/ueransim/ue/ue-deployment.yaml
+++ b/ueransim/ue/ue-deployment.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ueransim-ue
+  labels:
+    app.kubernetes.io/version: "v3.2.6"
+    app: ueransim
+    component: ue
+spec:
+  selector:
+    matchLabels:
+      app: ueransim
+      component: ue
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ueransim
+        component: ue
+    spec:
+      containers:
+      - image: towards5gs/ueransim-ue:v3.2.6
+        imagePullPolicy: IfNotPresent
+        name: ue
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
+        command: ["/ueransim/config/wrapper.sh"]
+        volumeMounts:
+        - mountPath: /ueransim/config
+          name: ue-volume
+        resources:
+            requests:
+              cpu: 120m
+              memory: 128Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+
+      volumes:
+      - name: ue-volume
+        configMap:
+          name: ue-configmap
+          items:
+          - key: ue-config.yaml
+            path: ue-config.yaml
+          - key: wrapper.sh
+            path: wrapper.sh
+            mode: 0755


### PR DESCRIPTION
Initial implementation of UERANSIM kpt package based on [Towards5gs helm charts](https://github.com/Orange-OpenSource/towards5gs-helm), as discussed in [nephio-project/nephio#105](https://github.com/nephio-project/nephio/issues/105)

UERANSIM packages will require to be specialized mannualy, when N2 and N3 endpoints will be known.

All service-level configuration stays as default Towards5gs configuration.
