### PR TITLE
Expose Nephio WebUI service

### DIFF
--- a/nephio-webui/service.yaml
+++ b/nephio-webui/service.yaml
@@ -3,8 +3,14 @@ kind: Service
 metadata:
   name: nephio-webui
   namespace: nephio-webui
+  labels:
+    app: nephio-webui
+    app.kubernetes.io/name: nephio-webui
+    app.kubernetes.io/instance: nephio-webui
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 172.18.0.201
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   selector:
     app: nephio-webui
   ports:


### PR DESCRIPTION
Resolves: https://github.com/nephio-project/nephio/issues/258

This change modifies the Nephio WebUI service type to LoadBalancer avoiding the usage of `kubectl port-forward` command